### PR TITLE
Updated MapList.txt

### DIFF
--- a/data/MapList.txt
+++ b/data/MapList.txt
@@ -9,7 +9,7 @@ mapList["Unknown Map"] := "Map not recognised or not supported"
 uniqueMapList := Object()
 uniqueMapList["Unknown Map"] := "Map not recognised or not supported"
 
-matchList := ["Arcade Map","Crystal Ore Map","Desert Map","Jungle Valley Map","Beach Map","Factory Map","Ghetto Map","Oasis Map","Arid Lake Map","Cavern Map","Channel Map","Grotto Map","Marshes Map","Sewer Map","Vaal Pyramid Map","Academy Map","Acid Lakes Map","Dungeon Map","Graveyard Map","Phantasmagoria Map","Villa Map","Waste Pool Map","Burial Chambers Map","Dunes Map","Mesa Map","Peninsula Map","Pit Map","Primordial Pool Map","Spider Lair Map","Tower Map","Canyon Map","Quarry Map","Racecourse Map","Ramparts Map","Spider Forest Map","Strand Map","Thicket Map","Vaal City Map","Wharf Map","Arachnid Tomb Map","Armory Map","Ashen Wood Map","Castle Ruins Map","Catacombs Map","Cells Map","Mud Geyser Map","Arachnid Nest Map","Arena Map","Atoll Map","Barrows Map","Bog Map","Cemetery Map","Pier Map","Shore Map","Tropical Island Map","Coves Map","Crypt Map","Museum Map","Orchard Map","Overgrown Shrine Map","Promenade Map","Reef Map","Temple Map","Arsenal Map","Colonnade Map","Courtyard Map","Malformation Map","Quay Map","Terrace Map","Underground River Map","Bazaar Map","Chateau Map","Excavation Map","Precinct Map","Torture Chamber Map","Underground Sea Map","Wasteland Map","Crematorium Map","Estuary Map","Ivory Temple Map","Necropolis Map","Plateau Map","Residence Map","Shipyard Map","Vault Map","Beacon Map","Gorge Map","High Gardens Map","Lair Map","Plaza Map","Scriptorium Map","Sulphur Wastes Map","Waterways Map","Maze Map","Mineral Pools Map","Palace Map","Shrine Map","Springs Map","Volcano Map","Abyss Map","Colosseum Map","Core Map","Dark Forest Map","Overgrown Ruin Map","Forge of the Phoenix Map","Lair of the Hydra Map","Maze of the Minotaur Map","Pit of the Chimera Map","Vaal Temple Map"]
+matchList := ["Arcade Map","Crystal Ore Map","Desert Map","Jungle Valley Map","Beach Map","Factory Map","Ghetto Map","Oasis Map","Arid Lake Map","Cavern Map","Channel Map","Grotto Map","Marshes Map","Sewer Map","Vaal Pyramid Map","Academy Map","Acid Lakes Map","Dungeon Map","Graveyard Map","Phantasmagoria Map","Villa Map","Waste Pool Map","Burial Chambers Map","Dunes Map","Mesa Map","Peninsula Map","Pit Map","Primordial Pool Map","Spider Lair Map","Tower Map","Canyon Map","Quarry Map","Racecourse Map","Ramparts Map","Spider Forest Map","Strand Map","Thicket Map","Vaal City Map","Wharf Map","Arachnid Tomb Map","Armoury Map","Ashen Wood Map","Castle Ruins Map","Catacombs Map","Cells Map","Mud Geyser Map","Arachnid Nest Map","Arena Map","Atoll Map","Barrows Map","Bog Map","Cemetery Map","Pier Map","Shore Map","Tropical Island Map","Coves Map","Crypt Map","Museum Map","Orchard Map","Overgrown Shrine Map","Promenade Map","Reef Map","Temple Map","Arsenal Map","Colonnade Map","Courtyard Map","Malformation Map","Quay Map","Terrace Map","Underground River Map","Bazaar Map","Chateau Map","Excavation Map","Precinct Map","Torture Chamber Map","Underground Sea Map","Wasteland Map","Crematorium Map","Estuary Map","Ivory Temple Map","Necropolis Map","Plateau Map","Residence Map","Shipyard Map","Vault Map","Beacon Map","Gorge Map","High Gardens Map","Lair Map","Plaza Map","Scriptorium Map","Sulphur Wastes Map","Waterways Map","Maze Map","Mineral Pools Map","Palace Map","Shrine Map","Springs Map","Volcano Map","Abyss Map","Colosseum Map","Core Map","Dark Forest Map","Overgrown Ruin Map","Forge of the Phoenix Map","Lair of the Hydra Map","Maze of the Minotaur Map","Pit of the Chimera Map","Vaal Temple Map"]
 
 mapList["Arcade Map"] := "Tier: 1, Level: 68, Atlas position: bottom right`nTileset: Marketplace`n`nUpgrades to: Ghetto Map`n`nDivination cards:`n- Assassin's Favour`n- The Gambler`n- Her Mask`n- The Poet"
 
@@ -82,7 +82,7 @@ mapList["Racecourse Map"] := "Tier: 6, Level: 73, Atlas position: top left`nTile
 
 mapList["Ramparts Map"] := "Tier: 6, Level: 73, Atlas position: right`nTileset: `n`nUpgrades to: Mud Geyser Map`nConnected to: Peninsula Map, Wharf Map"
 
-mapList["Spider Forest Map"] := "Tier: 6, Level: 73, Atlas position: right`nTileset: The Blackwood (Outdoors)`n`nProduced by: Tower Map, Spider Lair Map`nUpgrades to: Armory Map`nConnected to: Mud Geyser Map`n`nDivination cards:`n- The Gambler`n- The Incantation`n- Her Mask"
+mapList["Spider Forest Map"] := "Tier: 6, Level: 73, Atlas position: right`nTileset: The Blackwood (Outdoors)`n`nProduced by: Tower Map, Spider Lair Map`nUpgrades to: Armoury Map`nConnected to: Mud Geyser Map`n`nDivination cards:`n- The Gambler`n- The Incantation`n- Her Mask"
 
 mapList["Strand Map"] := "Tier: 6, Level: 73, Atlas position: top right`nTileset: Twilight Strand (Outdoors)`n`nProduced by: Dunes Map`nUpgrades to: Castle Ruins Map`n`nUnique version of map: Whakawairua Tuahu`n`nDivination cards:`n- Rain Tempter"
 
@@ -97,7 +97,7 @@ mapList["Wharf Map"] := "Tier: 6, Level: 73, Atlas position: top right`nTileset:
 
 mapList["Arachnid Tomb Map"] := "Tier: 7, Level: 74, Atlas position: bottom left`nTileset:  (Indoors. Multilevel. Boss is located on the last level.)`n`nUpgrades to: Tropical Island Map`nConnected to: Vaal City Map, Shore Map"
 
-mapList["Armory Map"] := "Tier: 7, Level: 74, Atlas position: bottom right`nTileset: `n`nProduced by: Spider Forest Map`nUpgrades to: Atoll Map`nConnected to: Pier Map, Arena Map"
+mapList["Armoury Map"] := "Tier: 7, Level: 74, Atlas position: bottom right`nTileset: `n`nProduced by: Spider Forest Map`nUpgrades to: Atoll Map`nConnected to: Pier Map, Arena Map"
 
 mapList["Ashen Wood Map"] := "Tier: 7, Level: 74, Atlas position: top left`nTileset: The Old Fields (Outdoors)`n`nProduced by: Quarry Map`nUpgrades to: Arachnid Nest Map`n`nDivination cards:`n- The Enlightened`n- The Gambler`n- Her Mask`n- The Pack Leader"
 
@@ -114,9 +114,9 @@ mapList["Mud Geyser Map"] := "Tier: 7, Level: 74, Atlas position: right`nTileset
 
 mapList["Arachnid Nest Map"] := "Tier: 8, Level: 75, Atlas position: top left`nTileset: The Weaver's Chambers (Indoors)`n`nProduced by: Ashen Wood Map, Cells Map`nUpgrades to: Overgrown Shrine Map`nConnected to: Overgrown Shrine Map`n`nDivination cards:`n- Bowyer's Dream`n- The Gambler`n- Her Mask"
 
-mapList["Arena Map"] := "Tier: 8, Level: 75, Atlas position: bottom right`nTileset: The Grand Arena (Indoors / Outdoors)`n`nUpgrades to: Orchard Map`nConnected to: Armory Map`n`nDivination cards:`n- The Arena Champion`n- The Gambler`n- The Gladiator`n- Her Mask`n- The Visionary"
+mapList["Arena Map"] := "Tier: 8, Level: 75, Atlas position: bottom right`nTileset: The Grand Arena (Indoors / Outdoors)`n`nUpgrades to: Orchard Map`nConnected to: Armoury Map`n`nDivination cards:`n- The Arena Champion`n- The Gambler`n- The Gladiator`n- Her Mask`n- The Visionary"
 
-mapList["Atoll Map"] := "Tier: 8, Level: 75, Atlas position: right`nTileset: The Ledge (Outdoors)`n`nProduced by: Armory Map, Pier Map (not connected)`nUpgrades to: Temple Map`n`nUnique version of map: Maelström of Chaos`n`nDivination cards:`n- The Gambler`n- Her Mask"
+mapList["Atoll Map"] := "Tier: 8, Level: 75, Atlas position: right`nTileset: The Ledge (Outdoors)`n`nProduced by: Armoury Map, Pier Map (not connected)`nUpgrades to: Temple Map`n`nUnique version of map: Maelström of Chaos`n`nDivination cards:`n- The Gambler`n- Her Mask"
 
 ;Maelström of Chaos
 uniqueMapList["Atoll Map"] := "Tier: 8, Level: 75, Atlas position: right`nTileset: The Ledge (Outdoors)`n`nDivination cards:`n- The Gambler`n- The Lover`n- The Siren"
@@ -127,7 +127,7 @@ mapList["Bog Map"] := "Tier: 8, Level: 75, Atlas position: top right`nTileset: F
 
 mapList["Cemetery Map"] := "Tier: 8, Level: 75, Atlas position: top right`nTileset: Fellshrine Ruins (Outdoors)`n`nProduced by: Castle Ruins Map`nUpgrades to: Crypt Map`nConnected to: Bog Map`n`nDivination cards:`n- The Gambler`n- Her Mask`n- The Soul"
 
-mapList["Pier Map"] := "Tier: 8, Level: 75, Atlas position: right`nTileset: The Docks (Outdoors)`n`nProduced by: Mud Geyser Map`nUpgrades to: Atoll Map (same tier; not connected)`nConnected to: Armory Map`n`nDivination cards:`n- The Gambler`n- Her Mask`n- Lucky Connections"
+mapList["Pier Map"] := "Tier: 8, Level: 75, Atlas position: right`nTileset: The Docks (Outdoors)`n`nProduced by: Mud Geyser Map`nUpgrades to: Atoll Map (same tier; not connected)`nConnected to: Armoury Map`n`nDivination cards:`n- The Gambler`n- Her Mask`n- Lucky Connections"
 
 mapList["Shore Map"] := "Tier: 8, Level: 75, Atlas position: bottom left`nTileset: The Coast (Outdoors)`n`nProduced by: Catacombs Map`nUpgrades to: Coves Map`nConnected to: Arachnid Tomb Map`n`nDivination cards:`n- The Gambler`n- Her Mask`n- The Inoculated`n- Prosperity`n- The Road to Power"
 


### PR DESCRIPTION
Changed "Armory Map" to "Armoury Map", as is spelled in-game.

Someone should also probably change the map name on [http://pathofexile.gamepedia.com/User:ARTyficial/MapData](http://pathofexile.gamepedia.com/User:ARTyficial/MapData) so future scrapings don't overwrite this. I can't do this (new account).